### PR TITLE
fix: Import missing dependency

### DIFF
--- a/ctdl/downloader.py
+++ b/ctdl/downloader.py
@@ -1,3 +1,4 @@
+import os
 import threading
 import requests
 from tqdm import tqdm, trange
@@ -63,7 +64,6 @@ def download_parallel(urls, directory):
         t.join()
 
     print("\nDownload complete.")
-
 
 
 def download_series(urls, directory):


### PR DESCRIPTION
- Fixed missing dependency `NameError: name 'os' is not defined`