### PR TITLE
fix: Max retries and back-off strategy for requests. Validate scraped links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.DS_Store
 *.pyc
 /dist/
 /*.egg
 /*.egg-info
+.idea/

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Here are some examples:
   $ ctdl -f ppt -l 3 health
   ```
 
-- To expicitly specify download folder:
+- To explicitly specify download folder:
 
   ```
   $ ctdl -d /home/nikhil/Desktop/ml-pdfs machine learning


### PR DESCRIPTION
- Fix retries error by adding max retries and back-off strategy so all requests to http:// sleep for specified period before retrying.
- Fix error when scrapes a link that is not prefixed with `http://` or `https://` and gives error
 `requests.exceptions.InvalidSchema: No connection adapters were found for '?q=filetype:jpg+test'`