### PR TITLE
feat: Add Max and Min file size CLI args. Fix max retries and back-off strategy in download requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ then the library `ctdl` may not have been updated to incorporate my changes. In 
         ```
 
 ```
-$ ctdl [-h] [-f FILE_TYPE] [-l LIMIT] [-d DIRECTORY] [-a] [-p] [query]
+$ ctdl [-h] [-f FILE_TYPE] [-l LIMIT] [-d DIRECTORY] [-p] [-a] [-t]
+       [-minfs MIN_FILE_SIZE] [-maxfs MAX_FILE_SIZE] [-nr]
+       [query]
 ```
 Optional arguments are:
 
@@ -59,6 +61,22 @@ Optional arguments are:
                  Default: A directory with same name as the search query in the current directory.
 
 - -p : for parallel downloading.
+
+- -a : list of all available filetypes.
+
+- -t : list of all common virus carrier filetypes.
+
+- -minfs MIN_FILE_SIZE : specify minimum file size to download in Kilobytes (KB).
+
+                 Default: 0
+
+- -maxfs MAX_FILE_SIZE : specify maximum file size to download in Kilobytes (KB).
+
+                 Default: -1 (represents no maximum file size)
+
+- -nr : prevent download redirects.
+
+                 Default: False
 
 Here are some examples:
 
@@ -98,6 +116,13 @@ Here are some examples:
   $ ctdl -f pdf -p python
   ```
 
+- To search for and download in parallel 10 files in PDF format containing
+  the text "python" and "algorithm", without allowing any url redirects,
+  and where the file size is between 10,000 KB (10 MB) and 100,000KB (100 MB),
+  where KB means Kilobytes, which has an equivalent value expressed in Megabytes:
+  ```
+  $ ctdl -f pdf -l 10 -minfs 10000 -maxfs 100000 -nr -p "python algorithm"`
+  ```
 
 ## Usage in Python files
 


### PR DESCRIPTION
- Updated Readme with new CLI args and example
- Fix MaxRetryError caused in download.py
- Fix file type flag to be -f instead of -g
- Add Max File Size and Min File Size arguments providing the ability to search only within a specific file size range.
- Add ability to not allow redirects (avoids potential exceptions like: `requests.exceptions.TooManyRedirects: Exceeded 30 redirects`)
- e.g. To search for and download in parallel 10 files in PDF format containing the text "python" and "algorithm", without allowing any url redirects, and where the file size is between 10,000 KB (10 MB) and 100,000KB (100 MB), where KB means Kilobytes, which has an equivalent value expressed in Megabytes:
	`ctdl -f pdf -l 10 -minfs 10000 -maxfs 100000 -nr -p "python algorithm"`