### PR TITLE
feat: All downloads saved 'downloads' root folder that is generated if not already exist

### DIFF
--- a/ctdl/downloader.py
+++ b/ctdl/downloader.py
@@ -24,12 +24,12 @@ retries = Retry(total = 5,
 s.mount('http://', HTTPAdapter(max_retries = retries))
 
 
-def download(url, directory, min_file_size = 0, max_file_size = -1, 
+def download(url, min_file_size = 0, max_file_size = -1,
 	         no_redirects = False, pos = 0, mode = 's'):
     global main_it
 
     file_name = url.split('/')[-1]
-    file_address = directory + '/' + file_name
+    file_address = settings.download_directory + '/' + file_name
     is_redirects = not no_redirects
 
     resp = s.get(url, stream = True, allow_redirects = is_redirects)
@@ -68,6 +68,17 @@ def download(url, directory, min_file_size = 0, max_file_size = -1,
         main_iter.update(1)
 
 
+def initialise_downloads(urls, directory):
+    """
+    Initialise globals including appJar GUI progress bar.
+    Important: Required otherwise lose context when debugging.
+    """
+    settings.urls_total_count = len(urls)
+    settings.urls_processed = 0
+    settings.urls_percent_complete = 1
+    settings.download_directory = create_new_download_directory(directory)
+
+
 def open_download_folder():
     """
     Open in a macOS Finder window the directory containing downloaded files
@@ -75,38 +86,63 @@ def open_download_folder():
     if sys.platform == "darwin":
         # macOS
 
-        # Cater for when run gui.py file directly in debugger within the examples directory
-        download_directory_full = sys.path[0]+'/'+settings.download_directory
-
-        if not os.path.isdir(download_directory_full):
-            # Cater for when run gui.py file from project root directory with `python examples/gui.py`
-            def get_main_path():
-                test_path = sys.path[0] # sys.path[0] is current path in 'examples' subdirectory
-                split_on_char = "/"
-                return split_on_char.join(test_path.split(split_on_char)[:-1])
-            main_path = get_main_path()
-            download_directory_full = main_path+"/"+settings.download_directory
-
-        subprocess.Popen(['open', download_directory_full])
+        subprocess.Popen(['open', settings.download_directory])
 
         # TODO - implement for linux and windows
         # elif platform == "linux" or platform == "linux2":
         # elif platform == "win32":
 
 
+def create_new_download_directory(directory):
+    """
+    Create new directory name within the root directory's 'downloads' folder.
+    Create the root directory's 'downloads' folder if it does not already exist.
+    Ensure functionality is correct (i.e. generates 'downloads' directory and new subfolder
+    in root project directory and not within an existing subfolder) whether we
+    run the executable from the root directory with say `python ctdl/ctdl.py` or
+    `python examples/gui.py`, or from within an existing subdirectory where the executable
+    is being run from like 'examples' or 'ctdl' such as when run with `cd examples; python gui.py`
+    or `cd ctdl; python ctdl.py`.
+
+    :param directory: new directory name to create for files being downloaded
+    :return: full path the new directory within the root directory's 'download' folder
+    """
+    # create directory within root directory's 'downloads' folder to save files
+    def get_parent_path():
+        test_path = sys.path[0]
+        split_on_char = "/"
+        return split_on_char.join(test_path.split(split_on_char)[:-1])
+
+    def get_current_directory_name(current_path):
+        return current_path.rsplit("/",1)[-1]
+
+    current_path = sys.path[0]
+    existing_subfolders = ["ctdl", "examples"]
+
+    if get_current_directory_name(current_path) in existing_subfolders:
+        # case when running from within subfolder
+        root_project_path = get_parent_path()
+    else:
+        # case when running from root project directory
+        root_project_path = current_path
+
+    main_downloads_path = root_project_path + "/downloads"
+
+    # create main 'downloads' subfolder if not exist
+    if not os.path.exists(main_downloads_path):
+        os.makedirs(main_downloads_path)
+
+    # create subfolder within 'downloads' folder to save files
+    new_download_path = main_downloads_path + "/" + directory
+    if not os.path.exists(new_download_path):
+        os.makedirs(new_download_path)
+
+    return new_download_path
+
 def download_parallel(urls, directory, min_file_size, max_file_size, no_redirects):
     global main_iter
 
-    # Initialise globals including appJar GUI progress bar
-    # Important: Required otherwise lose context when debugging.
-    settings.urls_total_count = len(urls)
-    settings.urls_processed = 0
-    settings.urls_percent_complete = 1
-    settings.download_directory = directory
-
-    # create directory to save files
-    if not os.path.exists(directory):
-        os.makedirs(directory)
+    initialise_downloads(urls, directory)
 
     # overall progress bar
     main_iter = trange(len(urls), position = 1, desc = yellow_color + "Overall")
@@ -120,7 +156,6 @@ def download_parallel(urls, directory, min_file_size, max_file_size, no_redirect
             target = download,
             kwargs = {
                 'url': url,
-                'directory': directory,
                 'pos': 2*idx+3,
                 'mode': 'p',
                 'min_file_size': min_file_size,
@@ -147,20 +182,11 @@ def download_parallel(urls, directory, min_file_size, max_file_size, no_redirect
 
 def download_series(urls, directory, min_file_size, max_file_size, no_redirects):
 
-    # Initialise globals including appJar GUI progress bar.
-    # Important: Required otherwise lose context when debugging.
-    settings.urls_total_count = len(urls)
-    settings.urls_processed = 0
-    settings.urls_percent_complete = 1
-    settings.download_directory = directory
-
-    # create directory to save files
-    if not os.path.exists(directory):
-        os.makedirs(directory)
+    initialise_downloads(urls, directory)
 
     # download files one by one
     for url in urls:
-        download(url, directory, min_file_size, max_file_size, no_redirects)
+        download(url, min_file_size, max_file_size, no_redirects)
 
     settings.urls_percent_complete = 100
     print("Download complete.")


### PR DESCRIPTION
- Create new directory name specified for downloading new files within the root directory's 'downloads' folder.
- Create the root directory's 'downloads' folder if it does not already exist.
- Ensures functionality is correct (i.e. generates 'downloads' directory and new subfolder
in root project directory and not within an existing subfolder) whether we
run the executable from the root directory with say `python ctdl/ctdl.py` or
`python examples/gui.py`, or from within an existing subdirectory where the executable
is being run from like 'examples' or 'ctdl' such as when run with `cd examples; python gui.py`
or `cd ctdl; python ctdl.py`.